### PR TITLE
add knative scaling annotations

### DIFF
--- a/supplychain-templates.yaml
+++ b/supplychain-templates.yaml
@@ -67,6 +67,9 @@ spec:
         metadata:
           labels:
             app.kubernetes.io/part-of: $(workload.name)
+          annotations:
+            autoscaling.knative.dev/minScale: "1"
+            autoscaling.knative.dev/maxScale: "1"
         spec:
           containers:
             - name: workload


### PR DESCRIPTION
https://www.pivotaltracker.com/story/show/177970796

As you know, we're adding a live reload scenario to the Educates lab. In support of that, we're adding this to prevent the Knative service from spinning down. This isn't the right final solution, but we've started the conversation with the Kontinue team about optional configuration.